### PR TITLE
contracts: fix assignment bug

### DIFF
--- a/contracts/UniswapERC20.sol
+++ b/contracts/UniswapERC20.sol
@@ -65,7 +65,7 @@ contract UniswapERC20 is ERC20 {
       require(inputIsA || inputToken == _tokenB);
       address outputToken = _tokenA;
       if(inputIsA) {
-        outputToken == _tokenB;
+        outputToken = _tokenB;
       }
 
       uint256 inputReserve = IERC20(inputToken).balanceOf(address(this));
@@ -92,7 +92,7 @@ contract UniswapERC20 is ERC20 {
       require(outputIsA || outputToken == _tokenB);
       address inputToken = _tokenA;
       if(outputIsA) {
-        inputToken == _tokenB;
+        inputToken = _tokenB;
       }
 
       uint256 inputReserve = IERC20(inputToken).balanceOf(address(this));


### PR DESCRIPTION
This fixes an apparent bug in the ERC20-ERC20 exchange contract, in which two methods use the equality operator `==` instead of the assignment operator `=`.