### PR TITLE
contracts: drop swapOutput

### DIFF
--- a/contracts/UniswapERC20.sol
+++ b/contracts/UniswapERC20.sol
@@ -48,15 +48,6 @@ contract UniswapERC20 is ERC20 {
     return numerator / denominator;
   }
 
-
-  function getOutputPrice(uint256 outputAmount, uint256 inputReserve, uint256 outputReserve) public pure returns (uint256) {
-    require(inputReserve > 0 && outputReserve > 0);
-    uint256 numerator = inputReserve.mul(outputAmount).mul(1000);
-    uint256 denominator = (outputReserve.sub(outputAmount)).mul(997);
-    return (numerator / denominator).add(1);
-  }
-
-
   //TO: DO msg.sender is wrapper
   function swapInput(address inputToken, uint256 amountSold, address recipient) public nonReentrant returns (uint256) {
       address _tokenA = address(tokenA);
@@ -96,21 +87,6 @@ contract UniswapERC20 is ERC20 {
     uint256 inputReserve = IERC20(inputToken).balanceOf(address(this));
     uint256 outputReserve = IERC20(outputToken).balanceOf(address(this));
     return getInputPrice(amountSold, inputReserve, outputReserve);
-  }
-
-
-  function getOutputPrice(address outputToken, uint256 amountBought) public view returns (uint256) {
-    require(amountBought > 0);
-    address _tokenA = address(tokenA);
-    address _tokenB = address(tokenB);
-    require(outputToken == _tokenA || outputToken == _tokenB);
-    address inputToken = _tokenA;
-    if(outputToken == _tokenA) {
-      inputToken = _tokenB;
-    }
-    uint256 inputReserve = IERC20(inputToken).balanceOf(address(this));
-    uint256 outputReserve = IERC20(outputToken).balanceOf(address(this));
-    return getOutputPrice(amountBought, inputReserve, outputReserve);
   }
 
 


### PR DESCRIPTION
This removes the swapOutput and getOutputPrice functions from the ERC20-ERC20 contract. We now think they can be implemented in the wrapper.