### PR TITLE
optimization: save 800 gas on update calls

### DIFF
--- a/contracts/UniswapV2Pair.sol
+++ b/contracts/UniswapV2Pair.sol
@@ -81,7 +81,7 @@ contract UniswapV2Pair is IUniswapV2Pair, UniswapV2ERC20 {
         }
         reserve0 = uint112(balance0);
         reserve1 = uint112(balance1);
-        blockTimestampLast = blockTimestamp;
+        if (timeElapsed > 0) { blockTimestampLast = blockTimestamp; }
         emit Sync(reserve0, reserve1);
     }
 


### PR DESCRIPTION
Solidity doesn't optimize these SSTORE calls for you, you have to manually tell it not to call SSTORE if the data is not changing