### PR TITLE
Fix PERMIT_TYPEHASH to match selector for permit()

### DIFF
--- a/contracts/UniswapV2ERC20.sol
+++ b/contracts/UniswapV2ERC20.sol
@@ -14,8 +14,8 @@ contract UniswapV2ERC20 is IUniswapV2ERC20 {
     mapping(address => mapping(address => uint)) public allowance;
 
     bytes32 public DOMAIN_SEPARATOR;
-    // keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
-    bytes32 public constant PERMIT_TYPEHASH = 0x6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9;
+    // keccak256("Permit(address owner,address spender,uint256 value,uint256 deadline)");
+    bytes32 public constant PERMIT_TYPEHASH = 0x05619a74ecd0240afc3bfb1df2bd1319401220fb577809c3a09bf0ab809ac861;
     mapping(address => uint) public nonces;
 
     event Approval(address indexed owner, address indexed spender, uint value);

--- a/test/UniswapV2ERC20.spec.ts
+++ b/test/UniswapV2ERC20.spec.ts
@@ -51,7 +51,7 @@ describe('UniswapV2ERC20', () => {
       )
     )
     expect(await token.PERMIT_TYPEHASH()).to.eq(
-      keccak256(toUtf8Bytes('Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)'))
+      keccak256(toUtf8Bytes('Permit(address owner,address spender,uint256 value,uint256 deadline)'))
     )
   })
 

--- a/test/shared/utilities.ts
+++ b/test/shared/utilities.ts
@@ -11,7 +11,7 @@ import {
 } from 'ethers/utils'
 
 const PERMIT_TYPEHASH = keccak256(
-  toUtf8Bytes('Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)')
+  toUtf8Bytes('Permit(address owner,address spender,uint256 value,uint256 deadline)')
 )
 
 export function expandTo18Decimals(n: number): BigNumber {


### PR DESCRIPTION
PERMIT_TYPEHASH wasn't updated when nonce was removed from the arguments for permit()