### PR TITLE
Remove duplicative pair storage

### DIFF
--- a/contracts/UniswapV2Factory.sol
+++ b/contracts/UniswapV2Factory.sol
@@ -31,8 +31,7 @@ contract UniswapV2Factory is IUniswapV2Factory {
             pair := create2(0, add(bytecode, 32), mload(bytecode), salt)
         }
         IUniswapV2Pair(pair).initialize(token0, token1);
-        getPair[token0][token1] = pair;
-        getPair[token1][token0] = pair; // populate mapping in the reverse direction
+        getPair[token0][token1] = pair; // single storage is sufficient
         allPairs.push(pair);
         emit PairCreated(token0, token1, pair, allPairs.length);
     }


### PR DESCRIPTION
This removes an unused `SSTORE` and saves 20,000 gas for pair deployment.