### PR TITLE
change SLOAD to MLOAD

### DIFF
--- a/contracts/UniswapV2Pair.sol
+++ b/contracts/UniswapV2Pair.sol
@@ -82,7 +82,7 @@ contract UniswapV2Pair is IUniswapV2Pair, UniswapV2ERC20 {
         reserve0 = uint112(balance0);
         reserve1 = uint112(balance1);
         blockTimestampLast = blockTimestamp;
-        emit Sync(reserve0, reserve1);
+        emit Sync(uint112(balance0), uint112(balance1));
     }
 
     // if fee is on, mint liquidity equivalent to 1/6th of the growth in sqrt(k)


### PR DESCRIPTION
Reading a state variable costs more gas than reading a local variable. If a state variable is read immediately after assignment, then replacing this read directly with the previously assigned local variable will change one SLOAD to one MLOAD to save some gases.