### PR TITLE
change SLOAD to MLOAD

### DIFF
--- a/contracts/UniswapV2ERC20.sol
+++ b/contracts/UniswapV2ERC20.sol
@@ -71,8 +71,9 @@ contract UniswapV2ERC20 is IUniswapV2ERC20 {
     }
 
     function transferFrom(address from, address to, uint value) external returns (bool) {
-        if (allowance[from][msg.sender] != uint(-1)) {
-            allowance[from][msg.sender] = allowance[from][msg.sender].sub(value);
+        uint allow_value = allowance[from][msg.sender];
+        if (allow_value != uint(-1)) {
+            allowance[from][msg.sender] = allow_value.sub(value);
         }
         _transfer(from, to, value);
         return true;

--- a/contracts/UniswapV2Pair.sol
+++ b/contracts/UniswapV2Pair.sol
@@ -82,7 +82,7 @@ contract UniswapV2Pair is IUniswapV2Pair, UniswapV2ERC20 {
         reserve0 = uint112(balance0);
         reserve1 = uint112(balance1);
         blockTimestampLast = blockTimestamp;
-        emit Sync(reserve0, reserve1);
+        emit Sync(uint112(balance0), uint112(balance1));
     }
 
     // if fee is on, mint liquidity equivalent to 1/6th of the growth in sqrt(k)


### PR DESCRIPTION
Reading a state variable costs more gas than reading a local variable. If a state variable is read immediately after assignment, then replacing this read directly with the previously assigned local variable will change one SLOAD to one MLOAD to save some gases. In the following example, function test6 costs 179 more gases than test7.

```
    function test6(uint bb) public {
        a112 = uint112(bb);
        emit Sync(a112);
    }

    function test7(uint bb) public {
        a112 = uint112(bb);
        emit Sync(uint112(bb));
    }
```