### PR TITLE
replace && with nested if to save gas

### DIFF
--- a/contracts/UniswapV2Pair.sol
+++ b/contracts/UniswapV2Pair.sol
@@ -74,10 +74,14 @@ contract UniswapV2Pair is IUniswapV2Pair, UniswapV2ERC20 {
         require(balance0 <= uint112(-1) && balance1 <= uint112(-1), 'UniswapV2: OVERFLOW');
         uint32 blockTimestamp = uint32(block.timestamp % 2**32);
         uint32 timeElapsed = blockTimestamp - blockTimestampLast; // overflow is desired
-        if (timeElapsed > 0 && _reserve0 != 0 && _reserve1 != 0) {
-            // * never overflows, and + overflow is desired
-            price0CumulativeLast += uint(UQ112x112.encode(_reserve1).uqdiv(_reserve0)) * timeElapsed;
-            price1CumulativeLast += uint(UQ112x112.encode(_reserve0).uqdiv(_reserve1)) * timeElapsed;
+        if (timeElapsed > 0) {
+            if (_reserve0 != 0) {
+                if (_reserve1 != 0) {
+                    // * never overflows, and + overflow is desired
+                    price0CumulativeLast += uint(UQ112x112.encode(_reserve1).uqdiv(_reserve0)) * timeElapsed;
+                    price1CumulativeLast += uint(UQ112x112.encode(_reserve0).uqdiv(_reserve1)) * timeElapsed;
+                }
+            }
         }
         reserve0 = uint112(balance0);
         reserve1 = uint112(balance1);


### PR DESCRIPTION
The solidity compiler generates more code for “if (A && B) {}” than for “if (A) {if (B) {} }”.
Replacing "if (A && B) {}" with "if (A) {if (B) {} }" can save gas.