### PR TITLE
save gas by avoid SQRT calculation

### DIFF
--- a/contracts/UniswapV2Pair.sol
+++ b/contracts/UniswapV2Pair.sol
@@ -92,9 +92,10 @@ contract UniswapV2Pair is IUniswapV2Pair, UniswapV2ERC20 {
         uint _kLast = kLast; // gas savings
         if (feeOn) {
             if (_kLast != 0) {
-                uint rootK = Math.sqrt(uint(_reserve0).mul(_reserve1));
-                uint rootKLast = Math.sqrt(_kLast);
-                if (rootK > rootKLast) {
+                uint k = _reserve0.mul(_reserve1);
+                if (k > _kLast) {
+                    uint rootK = Math.sqrt(k);
+                    uint rootKLast = Math.sqrt(_kLast);
                     uint numerator = totalSupply.mul(rootK.sub(rootKLast));
                     uint denominator = rootK.mul(5).add(rootKLast);
                     uint liquidity = numerator / denominator;


### PR DESCRIPTION
SQRT used for commission calculation but for condition it's not required because operator ">" would be same. Once condition is false then extra SQRT operation happen. That could be optimized at this commit.